### PR TITLE
Process in-memory-contents of files as opposed to their on-disk-contents

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function gulpTemplator (options) {
     }
 
     if (file.isBuffer()) {
-      content = templator.processFile(file.path);
+      content = templator.processContent(file.contents.toString(enc));
       file.contents = new Buffer(content, enc);
     }
 


### PR DESCRIPTION
Fixes #9 by switching templator from processing file paths to just processing the content of the files
